### PR TITLE
Fix handling of inactive alarms in main function

### DIFF
--- a/example.py
+++ b/example.py
@@ -44,6 +44,11 @@ async def main():
         alarm_id = int(input(f"Enter the alarm id ({options}): "))
         print("Loading alarm metadata...")
         alarm_addr = await client.get_alarm_address(alarm_id)
+        alarm_state = await client.get_address_state(alarm_addr)
+        if alarm_state != "active":
+            sys.stdout.write("\033[F")
+            print("Sorry, the alarm is not active, you can't wind it.")
+            return
         alarm_metadata = await client.get_alarm_metadata(alarm_addr)
         remain_scale = alarm_metadata.remain_scale
         decimal_ratio = 10 ** (client.metadata.base_asset_decimals - client.metadata.quote_asset_decimals)

--- a/ticton/callbacks.py
+++ b/ticton/callbacks.py
@@ -70,7 +70,7 @@ async def _handle_tick(
     try:
         tick_msg = TicTonMessage.Tick.parse(body)
     except Exception as e:
-        print(f"Handle tick failed: {traceback.format_exc()} ")
+        print(f"Handle tick failed: {e} ")
         return
     for candidate in tx.out_msgs:
         if candidate.message_content is None:

--- a/ticton/client.py
+++ b/ticton/client.py
@@ -10,9 +10,28 @@ from tonsdk.utils import bytes_to_b64str
 from tonsdk.boc import Cell, begin_cell
 from tonsdk.contract.wallet import Wallets
 from tonpy import CellSlice
-from typing import Any, Coroutine, Dict, Tuple, Optional, Literal, Callable, List, Type, Union
+from typing import (
+    Any,
+    Coroutine,
+    Dict,
+    Tuple,
+    Optional,
+    Literal,
+    Callable,
+    List,
+    Type,
+    Union,
+)
 from .arithmetic import FixedFloat, to_token, token_to_float
-from .callbacks import OnTickSuccessParams, OnWindSuccessParams, OnRingSuccessParams, handle_noop, handle_chime, handle_chronoshift, handle_notification
+from .callbacks import (
+    OnTickSuccessParams,
+    OnWindSuccessParams,
+    OnRingSuccessParams,
+    handle_noop,
+    handle_chime,
+    handle_chronoshift,
+    handle_notification,
+)
 from pytoncenter.extension.message import JettonMessage
 from .parser import TicTonMessage
 from os import getenv
@@ -45,9 +64,16 @@ __all__ = ["TicTonAsyncClient"]
 
 
 class SubscribeParam(BaseModel):
-    start_lt: Optional[int] = Field(default=None, description="The lt to start from, if None, the oldest lt will be used")
-    interval: float = Field(default=2.0, description="The interval of the subscription in seconds")
-    limit: int = Field(default=256, ge=1, le=256, description="The limit of the subscription")
+    start_lt: Optional[int] = Field(
+        default=None,
+        description="The lt to start from, if None, the oldest lt will be used",
+    )
+    interval: float = Field(
+        default=2.0, description="The interval of the subscription in seconds"
+    )
+    limit: int = Field(
+        default=256, ge=1, le=256, description="The limit of the subscription"
+    )
     offset: int = Field(default=0, ge=0, description="The offset of the subscription")
     account: AddressLike = Field(..., description="The account to subscribe to")
 
@@ -59,7 +85,9 @@ class TicTonAsyncClient:
         toncenter: AsyncTonCenterClientV3,
         oracle_addr: AddressLike,
         mnemonics: Optional[str] = None,
-        wallet_version: Literal["v2r1", "v2r2", "v3r1", "v3r2", "v4r1", "v4r2", "hv2"] = "v4r2",
+        wallet_version: Literal[
+            "v2r1", "v2r2", "v3r1", "v3r2", "v4r1", "v4r2", "hv2"
+        ] = "v4r2",
         threshold_price: float = 0.7,
         *,
         logger: Optional[logging.Logger] = None,
@@ -88,7 +116,9 @@ class TicTonAsyncClient:
         mnemonics: Optional[str] = None,
         oracle_addr: Optional[str] = None,
         toncenter_api_key: Optional[str] = None,
-        wallet_version: Literal["v2r1", "v2r2", "v3r1", "v3r2", "v4r1", "v4r2", "hv2"] = "v4r2",
+        wallet_version: Literal[
+            "v2r1", "v2r2", "v3r1", "v3r2", "v4r1", "v4r2", "hv2"
+        ] = "v4r2",
         threshold_price: float = 0.01,
         *,
         testnet: bool = True,
@@ -99,7 +129,9 @@ class TicTonAsyncClient:
         oracle_addr_str = getenv("TICTON_ORACLE_ADDRESS", oracle_addr)
         toncenter_api_key = getenv("TICTON_TONCENTER_API_KEY", toncenter_api_key)
         threshold_price = float(getenv("TICTON_THRESHOLD_PRICE", threshold_price))
-        assert oracle_addr_str is not None, "oracle_addr must be provided, you can either pass it as a parameter or set TICTON_ORACLE_ADDRESS environment variable"
+        assert (
+            oracle_addr_str is not None
+        ), "oracle_addr must be provided, you can either pass it as a parameter or set TICTON_ORACLE_ADDRESS environment variable"
 
         toncenter = get_client(
             version="v3",
@@ -107,7 +139,11 @@ class TicTonAsyncClient:
             custom_api_key=toncenter_api_key,
         )
 
-        raw_oracle_metadata = await toncenter.run_get_method(RunGetMethodRequest(address=oracle_addr_str, method="getOracleData", stack=[]))
+        raw_oracle_metadata = await toncenter.run_get_method(
+            RunGetMethodRequest(
+                address=oracle_addr_str, method="getOracleData", stack=[]
+            )
+        )
         metadata = OracleMetadataDecoder().decode(raw_oracle_metadata)
 
         return cls(
@@ -126,14 +162,22 @@ class TicTonAsyncClient:
         """
         assert price > 0, "price must be greater than 0"
         price = float(price)
-        return FixedFloat(price) * 10**self.metadata.quote_asset_decimals / 10**self.metadata.base_asset_decimals
+        return (
+            FixedFloat(price)
+            * 10**self.metadata.quote_asset_decimals
+            / 10**self.metadata.base_asset_decimals
+        )
 
     async def _convert_fixedfloat_to_price(self, price: FixedFloat) -> float:
         """
         Adjusts the given price by scaling it to match the decimal difference between the quote and base assets in a token pair.
         """
         assert isinstance(price, FixedFloat), "price must be a FixedFloat"
-        return price.to_float() * 10**self.metadata.base_asset_decimals / 10**self.metadata.quote_asset_decimals
+        return (
+            price.to_float()
+            * 10**self.metadata.base_asset_decimals
+            / 10**self.metadata.quote_asset_decimals
+        )
 
     def assert_wallet_exists(self):
         assert hasattr(self, "wallet"), "wallet is not found"
@@ -151,10 +195,16 @@ class TicTonAsyncClient:
         """
         self.assert_wallet_exists()
 
-        async def _get_balance(master_address: PyAddress, account_address: PyAddress) -> Decimal:
+        async def _get_balance(
+            master_address: PyAddress, account_address: PyAddress
+        ) -> Decimal:
 
-            if master_address == PyAddress("0:0000000000000000000000000000000000000000000000000000000000000000"):
-                account = await self.toncenter.get_account(GetAccountRequest(address=account_address.to_string()))
+            if master_address == PyAddress(
+                "0:0000000000000000000000000000000000000000000000000000000000000000"
+            ):
+                account = await self.toncenter.get_account(
+                    GetAccountRequest(address=account_address.to_string())
+                )
                 return Decimal(account.balance)
             else:
                 jetton = await self.toncenter.get_jetton_wallets(
@@ -177,8 +227,12 @@ class TicTonAsyncClient:
             ),
         )
 
-        assert isinstance(base_asset_balance, Decimal), "base_asset_balance is not Decimal"
-        assert isinstance(quote_asset_balance, Decimal), "quote_asset_balance is not Decimal"
+        assert isinstance(
+            base_asset_balance, Decimal
+        ), "base_asset_balance is not Decimal"
+        assert isinstance(
+            quote_asset_balance, Decimal
+        ), "quote_asset_balance is not Decimal"
 
         return (base_asset_balance, quote_asset_balance)
 
@@ -212,7 +266,9 @@ class TicTonAsyncClient:
             payload=body,
         )
         boc: bytearray = query["message"].to_boc(False)
-        result = await self.toncenter.send_message(ExternalMessage(boc=bytes_to_b64str(boc)))
+        result = await self.toncenter.send_message(
+            ExternalMessage(boc=bytes_to_b64str(boc))
+        )
         return result
 
     async def _estimate_from_oracle_get_method(
@@ -272,7 +328,9 @@ class TicTonAsyncClient:
             can_buy,
             need_base_asset,
             need_quote_asset,
-        ) = await self._estimate_from_oracle_get_method(alarm_address.to_string(), buy_num, int(new_price_ff.raw_value))
+        ) = await self._estimate_from_oracle_get_method(
+            alarm_address.to_string(), buy_num, int(new_price_ff.raw_value)
+        )
 
         return (
             can_buy,
@@ -283,7 +341,10 @@ class TicTonAsyncClient:
     async def _can_afford(self, need_base_asset: Decimal, need_quote_asset: Decimal):
         base_asset_balance, quote_asset_balance = await self._get_user_balance()
         gas_fee = 1 * 10**9
-        if need_base_asset + gas_fee > base_asset_balance or need_quote_asset > quote_asset_balance:
+        if (
+            need_base_asset + gas_fee > base_asset_balance
+            or need_quote_asset > quote_asset_balance
+        ):
             return False
         return True
 
@@ -291,27 +352,39 @@ class TicTonAsyncClient:
         """
         get the alarm info
         """
-        result = await self.toncenter.run_get_method(RunGetMethodRequest(address=alarm_address.to_string(), method="getAlarmMetadata", stack=[]))
+        result = await self.toncenter.run_get_method(
+            RunGetMethodRequest(
+                address=alarm_address.to_string(), method="getAlarmMetadata", stack=[]
+            )
+        )
         return AlarmMetadataDecoder().decode(result)  # type: ignore
 
     async def check_alarms(self, alarm_id_list: List[int]):
         self.logger.info("Checking Alarms State")
 
-        address_list = await self.toncenter.multicall([self.get_alarm_address(alarm_id) for alarm_id in alarm_id_list])
+        address_list = await self.toncenter.multicall(
+            [self.get_alarm_address(alarm_id) for alarm_id in alarm_id_list]
+        )
 
         # get alarm state
-        state_list = await self.toncenter.multicall([self.get_address_state(address) for address in address_list])
+        state_list = await self.toncenter.multicall(
+            [self.get_address_state(address) for address in address_list]
+        )
 
         # update alarm dict
         alarm_dict = {}
-        for alarm_id, alarm_address, alarm_state in zip(alarm_id_list, address_list, state_list):
+        for alarm_id, alarm_address, alarm_state in zip(
+            alarm_id_list, address_list, state_list
+        ):
             alarm_dict[alarm_id] = {}
             alarm_dict[alarm_id]["state"] = alarm_state
             alarm_dict[alarm_id]["address"] = alarm_address
 
         return alarm_dict
 
-    async def tick(self, price: float, *, timeout: int = 1000, extra_ton: float = 0.1, **kwargs):
+    async def tick(
+        self, price: float, *, timeout: int = 1000, extra_ton: float = 0.1, **kwargs
+    ):
         """
         tick will open a position with the given price and timeout, the total amount
         of baseAsset and quoteAsset will be calculated automatically.
@@ -339,19 +412,34 @@ class TicTonAsyncClient:
         assert price > 0, "price must be greater than 0"
         self.assert_wallet_exists()
         expire_at = int(time.time()) + timeout
+        price = round(price, self.metadata.quote_asset_decimals)
         base_asset_price = await self._convert_price(price)
-        quote_asset_transfered = FixedFloat(to_token(price, self.metadata.quote_asset_decimals))
-        forward_ton_amount = quote_asset_transfered / base_asset_price + to_token(extra_ton, self.metadata.base_asset_decimals)
+        quote_asset_transfered = FixedFloat(
+            to_token(price, self.metadata.quote_asset_decimals)
+        )
+        forward_ton_amount = quote_asset_transfered / base_asset_price + to_token(
+            extra_ton, self.metadata.base_asset_decimals
+        )
         base_asset_price = int(base_asset_price.raw_value)
         quote_asset_transfered = quote_asset_transfered.to_float()
         forward_ton_amount = int(round(forward_ton_amount.to_float(), 0))
         gas_fee = int(0.13 * 10**9)
 
-        can_afford = await self._can_afford(Decimal(forward_ton_amount + gas_fee), quote_asset_transfered)
+        can_afford = await self._can_afford(
+            Decimal(forward_ton_amount + gas_fee), Decimal(quote_asset_transfered)
+        )
         assert can_afford, "not enough balance"
-        forward_info = begin_cell().store_uint(0, 8).store_uint(expire_at, 256).store_uint(base_asset_price, 256).end_cell()
+        forward_info = (
+            begin_cell()
+            .store_uint(0, 8)
+            .store_uint(expire_at, 256)
+            .store_uint(base_asset_price, 256)
+            .end_cell()
+        )
 
-        wallet_info = await self.toncenter.get_wallet(GetWalletRequest(address=self.wallet.address.to_string()))
+        wallet_info = await self.toncenter.get_wallet(
+            GetWalletRequest(address=self.wallet.address.to_string())
+        )
 
         body = (
             begin_cell()
@@ -385,10 +473,14 @@ class TicTonAsyncClient:
 
         args = [
             price,
-            token_to_float(forward_ton_amount + gas_fee, self.metadata.base_asset_decimals),
+            token_to_float(
+                forward_ton_amount + gas_fee, self.metadata.base_asset_decimals
+            ),
             token_to_float(quote_asset_transfered, self.metadata.quote_asset_decimals),
         ]
-        log_info = ("Tick message successfully sent, tick price: {}, spend base asset: {}, spend quote asset: {}").format(*args)
+        log_info = (
+            "Tick message successfully sent, tick price: {}, spend base asset: {}, spend quote asset: {}"
+        ).format(*args)
         self.logger.info(log_info)
 
         return result
@@ -413,10 +505,18 @@ class TicTonAsyncClient:
         alarm_address = await self.get_alarm_address(alarm_id)
         alarm_state = await self.get_address_state(alarm_address)
         assert alarm_state == "active", "Ring: alarm is not exist"
-        wallet = await self.toncenter.get_wallet(GetWalletRequest(address=self.wallet.address.to_string()))
+        wallet = await self.toncenter.get_wallet(
+            GetWalletRequest(address=self.wallet.address.to_string())
+        )
         assert wallet.seqno is not None, "Ring: seqno is not found in wallet info"
         gas_fee = int(0.35 * 10**9)
-        body = begin_cell().store_uint(0xC3510A29, 32).store_uint(1, 257).store_uint(alarm_id, 257).end_cell()  # query_id cannot be 0
+        body = (
+            begin_cell()
+            .store_uint(0xC3510A29, 32)
+            .store_uint(1, 257)
+            .store_uint(alarm_id, 257)
+            .end_cell()
+        )  # query_id cannot be 0
         result = await self._send(
             to_address=self.oracle.to_string(),
             amount=gas_fee,
@@ -473,21 +573,36 @@ class TicTonAsyncClient:
             assert need_base_asset is not None, "need_base_asset must be provided"
             assert need_quote_asset is not None, "need_quote_asset must be provided"
         else:
-            can_buy, need_asset_tup, _ = await self._estimate_wind(alarm_id, buy_num, new_price)
+            can_buy, need_asset_tup, _ = await self._estimate_wind(
+                alarm_id, buy_num, new_price
+            )
             assert can_buy, "Buy num is too large"
-            assert need_asset_tup is not None, "The price difference is smaller than threshold price"
+            assert (
+                need_asset_tup is not None
+            ), "The price difference is smaller than threshold price"
 
             need_base_asset, need_quote_asset = need_asset_tup
 
-        wallet = await self.toncenter.get_wallet(GetWalletRequest(address=self.wallet.address.to_string()))
+        wallet = await self.toncenter.get_wallet(
+            GetWalletRequest(address=self.wallet.address.to_string())
+        )
         assert wallet.seqno is not None, "seqno is not found in wallet info"
 
         gas_fee = int(0.5 * 10**9)
 
-        can_afford = await self._can_afford(Decimal(need_base_asset + gas_fee), need_quote_asset)
+        can_afford = await self._can_afford(
+            Decimal(need_base_asset + gas_fee), need_quote_asset
+        )
         assert can_afford, "not enough balance"
 
-        forward_info = begin_cell().store_uint(1, 8).store_uint(alarm_id, 256).store_uint(buy_num, 32).store_uint(int(new_price_ff.raw_value), 256).end_cell()
+        forward_info = (
+            begin_cell()
+            .store_uint(1, 8)
+            .store_uint(alarm_id, 256)
+            .store_uint(buy_num, 32)
+            .store_uint(int(new_price_ff.raw_value), 256)
+            .end_cell()
+        )
 
         body = (
             begin_cell()
@@ -525,14 +640,24 @@ class TicTonAsyncClient:
             token_to_float(need_base_asset, self.metadata.base_asset_decimals),
             token_to_float(need_quote_asset, self.metadata.quote_asset_decimals),
         ]
-        log_info = ("Wind message successfully sent, alarm id: {}, buy num: {}, wind price: {}, spend base asset: {}, spend quote asset: {}").format(*args)
+        log_info = (
+            "Wind message successfully sent, alarm id: {}, buy num: {}, wind price: {}, spend base asset: {}, spend quote asset: {}"
+        ).format(*args)
         self.logger.info(log_info)
 
         return result
 
-    async def _validate_subscribe_param(self, start_lt: Union[int, Literal["latest", "oldest"]], interval: Union[int, float], limit: int) -> SubscribeParam:
+    async def _validate_subscribe_param(
+        self,
+        start_lt: Union[int, Literal["latest", "oldest"]],
+        interval: Union[int, float],
+        limit: int,
+    ) -> SubscribeParam:
         # Check start_lt
-        assert isinstance(start_lt, int) or start_lt in ["latest", "oldest"], "start_lt must be an int or 'latest' or 'oldest'"
+        assert isinstance(start_lt, int) or start_lt in [
+            "latest",
+            "oldest",
+        ], "start_lt must be an int or 'latest' or 'oldest'"
         # Default option is "oldest"
         begin_lt = None
         if isinstance(start_lt, int):
@@ -556,9 +681,15 @@ class TicTonAsyncClient:
 
     async def subscribe(
         self,
-        on_tick_success: Callable[[OnTickSuccessParams], Coroutine[Any, Any, None]] = handle_noop,
-        on_wind_success: Callable[[OnWindSuccessParams], Coroutine[Any, Any, None]] = handle_noop,
-        on_ring_success: Callable[[OnRingSuccessParams], Coroutine[Any, Any, None]] = handle_noop,
+        on_tick_success: Callable[
+            [OnTickSuccessParams], Coroutine[Any, Any, None]
+        ] = handle_noop,
+        on_wind_success: Callable[
+            [OnWindSuccessParams], Coroutine[Any, Any, None]
+        ] = handle_noop,
+        on_ring_success: Callable[
+            [OnRingSuccessParams], Coroutine[Any, Any, None]
+        ] = handle_noop,
         start_lt: Union[int, Literal["latest", "oldest"]] = "oldest",
         interval: Union[int, float] = 2.0,
         *,


### PR DESCRIPTION
This pull request fixes the handling of inactive alarms in the main function. Previously, when attempting to wind an inactive alarm, an error would occur. This PR adds a check to ensure that only active alarms can be wound.