### PR TITLE
Updated the error handling in client.py

### DIFF
--- a/ticton/client.py
+++ b/ticton/client.py
@@ -240,10 +240,10 @@ class TicTonAsyncClient:
             ),
         )
 
-        if isinstance(base_asset_balance, AssertionError):
+        if isinstance(base_asset_balance, AssertionError) or isinstance(base_asset_balance, Exception):
             warnings.warn(f"your base asset balance is not found. reason: {base_asset_balance}")
             base_asset_balance = Decimal(0)
-        if isinstance(quote_asset_balance, AssertionError):
+        if isinstance(quote_asset_balance, AssertionError) or isinstance(quote_asset_balance, Exception):
             warnings.warn(f"your quote asset balance is not found. reason: {quote_asset_balance}")
             quote_asset_balance = Decimal(0)
 


### PR DESCRIPTION
This PR addresses an issue where the `base_asset_balance` and `quote_asset_balance` in the `client.py` file are sometimes instances of `TonCenterException`, leading to errors in the `bot.py` file when comparing balance values.

Error messages:
```
Exception in thread Thread-3 (run):
Traceback (most recent call last):
  File "/usr/local/lib/python3.10/threading.py", line 1016, in _bootstrap_inner
    self.run()
  File "/usr/local/lib/python3.10/threading.py", line 953, in run
    self._target(*self._args, **self._kwargs)
  File "/usr/local/lib/python3.10/asyncio/runners.py", line 44, in run
    return loop.run_until_complete(main)
  File "/usr/local/lib/python3.10/asyncio/base_events.py", line 649, in run_until_complete
    return future.result()
  File "/usr/src/app/./bot.py", line 148, in main
    buy_num = await check_balance(
  File "/usr/src/app/./bot.py", line 39, in check_balance
    if balance.base_asset < need_base or balance.quote_asset < need_quote:
TypeError: '<' not supported between instances of 'TonCenterException' and 'decimal.Decimal'
```